### PR TITLE
Feature/workspaces

### DIFF
--- a/Finite/Finite.xcodeproj/project.pbxproj
+++ b/Finite/Finite.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		A100000019 /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000001D /* SparkleUpdater.swift */; };
 		A100000017 /* terminfo in Resources */ = {isa = PBXBuildFile; fileRef = B10000001B /* terminfo */; };
 		A100000018 /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B10000001C /* ghostty */; };
+		A10000001F /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000001F /* Workspace.swift */; };
+		A100000020 /* WorkspaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000020 /* WorkspaceManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +61,8 @@
 		B10000001E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B10000001B /* terminfo */ = {isa = PBXFileReference; lastKnownFileType = folder; path = terminfo; sourceTree = "<group>"; };
 		B10000001C /* ghostty */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ghostty; sourceTree = "<group>"; };
+		B10000001F /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
+		B100000020 /* WorkspaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +102,7 @@
 				E100000003 /* Canvas */,
 				E100000004 /* Terminal */,
 				E100000005 /* Sidebar */,
+				E10000000A /* Workspace */,
 				E100000009 /* UI */,
 			);
 			path = Sources;
@@ -170,6 +175,15 @@
 				B100000018 /* ToolbarButtonsView.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		E10000000A /* Workspace */ = {
+			isa = PBXGroup;
+			children = (
+				B10000001F /* Workspace.swift */,
+				B100000020 /* WorkspaceManager.swift */,
+			);
+			path = Workspace;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -261,6 +275,8 @@
 				A100000013 /* SnapGuideEngine.swift in Sources */,
 				A100000014 /* ToolbarButtonsView.swift in Sources */,
 				A100000019 /* SparkleUpdater.swift in Sources */,
+				A10000001F /* Workspace.swift in Sources */,
+				A100000020 /* WorkspaceManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Finite/Makefile
+++ b/Finite/Makefile
@@ -4,11 +4,19 @@ APP_NAME := Finite.app
 DERIVED_DATA := $(HOME)/Library/Developer/Xcode/DerivedData
 INSTALL_DIR := /Applications
 
-.PHONY: build release clean setup distribute
+.PHONY: build run release clean setup distribute
 
-## Development build
+CODESIGN_OVERRIDE := CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+## Development build (unsigned)
 build: setup
-	xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug build
+	xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug build $(CODESIGN_OVERRIDE)
+
+## Build and run
+run: build
+	@APP=$$(find $(DERIVED_DATA) -path "*/Finite-*/Build/Products/Debug/$(APP_NAME)" -maxdepth 5 2>/dev/null | head -1); \
+	if [ -z "$$APP" ]; then echo "Error: could not find built $(APP_NAME)"; exit 1; fi; \
+	open "$$APP"
 
 ## Release build + copy to /Applications
 release: setup

--- a/Finite/Makefile
+++ b/Finite/Makefile
@@ -4,19 +4,11 @@ APP_NAME := Finite.app
 DERIVED_DATA := $(HOME)/Library/Developer/Xcode/DerivedData
 INSTALL_DIR := /Applications
 
-.PHONY: build run release clean setup distribute
+.PHONY: build release clean setup distribute
 
-CODESIGN_OVERRIDE := CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-
-## Development build (unsigned)
+## Development build
 build: setup
-	xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug build $(CODESIGN_OVERRIDE)
-
-## Build and run
-run: build
-	@APP=$$(find $(DERIVED_DATA) -path "*/Finite-*/Build/Products/Debug/$(APP_NAME)" -maxdepth 5 2>/dev/null | head -1); \
-	if [ -z "$$APP" ]; then echo "Error: could not find built $(APP_NAME)"; exit 1; fi; \
-	open "$$APP"
+	xcodebuild -project $(XCODEPROJ) -scheme $(SCHEME) -configuration Debug build
 
 ## Release build + copy to /Applications
 release: setup

--- a/Finite/Sources/AppDelegate.swift
+++ b/Finite/Sources/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // for NSApplicationDelegate when not using storyboards.
     private var window: NSWindow!
     private var canvasView: CanvasView!
-    private var nodeManager: TerminalNodeManager!
+    private var workspaceManager: WorkspaceManager!
     private var sidebarModel: SidebarModel!
     private var sidebarOverlay: SidebarOverlayView!
     private var minimapView: MinimapView!
@@ -26,6 +26,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var processStateTimer: Timer?
     private var cachedProcessStates: [Bool] = []
     private var keyboardMonitor: Any?
+
+    private var activeNodeManager: TerminalNodeManager {
+        workspaceManager.activeWorkspace.nodeManager
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Initialize the Ghostty runtime (config, app, callbacks)
@@ -65,18 +69,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         gridView.canvasView = canvasView
         container.addSubview(canvasView)
 
-        // Create node manager
-        nodeManager = TerminalNodeManager(canvasView: canvasView, window: window)
-        nodeManager.delegate = self
+        // Create workspace manager
+        workspaceManager = WorkspaceManager(canvasView: canvasView, window: window)
+        workspaceManager.delegate = self
 
         // Create sidebar model
         sidebarModel = SidebarModel()
         sidebarModel.onSelectNode = { [weak self] node, mods in
-            self?.nodeManager.handleClick(node, modifiers: mods)
+            self?.activeNodeManager.handleClick(node, modifiers: mods)
             self?.ensureNodeVisible(node)
         }
         sidebarModel.onPanToNode = { [weak self] node in
-            self?.nodeManager.handleClick(node, modifiers: [])
+            self?.activeNodeManager.handleClick(node, modifiers: [])
             self?.panToNode(node)
         }
         sidebarModel.onHoverPulse = { [weak self] node in
@@ -87,10 +91,31 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.closeSelectedTerminals()
         }
         sidebarModel.onCloseSingle = { [weak self] node in
-            self?.nodeManager.requestCloseNode(node)
+            self?.activeNodeManager.requestCloseNode(node)
         }
         sidebarModel.onDuplicateNode = { [weak self] node in
-            self?.nodeManager.duplicateNode(node)
+            self?.activeNodeManager.duplicateNode(node)
+        }
+        sidebarModel.onSelectWorkspace = { [weak self] id in
+            guard let self else { return }
+            if let workspace = self.workspaceManager.workspaces.first(where: { $0.id == id }) {
+                self.workspaceManager.switchTo(workspace: workspace)
+            }
+        }
+        sidebarModel.onCreateWorkspace = { [weak self] in
+            self?.newWorkspace(nil)
+        }
+        sidebarModel.onDeleteWorkspace = { [weak self] id in
+            guard let self else { return }
+            if let workspace = self.workspaceManager.workspaces.first(where: { $0.id == id }) {
+                self.deleteWorkspace(workspace)
+            }
+        }
+        sidebarModel.onRenameWorkspace = { [weak self] id, name in
+            guard let self else { return }
+            if let workspace = self.workspaceManager.workspaces.first(where: { $0.id == id }) {
+                self.workspaceManager.renameWorkspace(workspace, to: name)
+            }
         }
 
         // Create sidebar overlay (glass panel inside the window)
@@ -107,13 +132,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             sidebarOverlay.heightAnchor.constraint(lessThanOrEqualTo: container.heightAnchor, multiplier: 0.6),
         ])
 
-        // Wire runtime callbacks to manager
+        // Wire runtime callbacks — surface-targeted ones route through workspaceManager
         GhosttyRuntime.shared.onSetTitle = { [weak self] surface, title in
-            self?.nodeManager.handleSetTitle(surface, title)
+            self?.workspaceManager.nodeManager(for: surface)?.handleSetTitle(surface, title)
         }
 
         GhosttyRuntime.shared.onSurfaceClosed = { [weak self] surface in
-            self?.nodeManager.handleSurfaceClosed(surface)
+            self?.workspaceManager.nodeManager(for: surface)?.handleSurfaceClosed(surface)
         }
 
         GhosttyRuntime.shared.onNewTerminal = { [weak self] in
@@ -125,23 +150,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         GhosttyRuntime.shared.onRender = { [weak self] surface in
-            self?.nodeManager.markActivity(for: surface)
+            self?.workspaceManager.nodeManager(for: surface)?.markActivity(for: surface)
         }
 
         GhosttyRuntime.shared.onPwdChanged = { [weak self] surface, pwd in
-            self?.nodeManager.handlePwdChanged(surface, pwd)
+            self?.workspaceManager.nodeManager(for: surface)?.handlePwdChanged(surface, pwd)
         }
 
         GhosttyRuntime.shared.onCloseSurfaceRequested = { [weak self] surface, _ in
             guard let self else { return }
-            guard let node = self.nodeManager.node(for: surface) else { return }
-            self.nodeManager.requestCloseNode(node)
+            guard let manager = self.workspaceManager.nodeManager(for: surface),
+                  let node = manager.node(for: surface) else { return }
+            manager.requestCloseNode(node)
         }
 
         // Minimap in bottom-right corner of the container
         minimapView = MinimapView(frame: .zero)
         minimapView.canvasView = canvasView
-        minimapView.nodeManager = nodeManager
         minimapView.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(minimapView)
 
@@ -193,8 +218,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let normalizedFlags = flags.subtracting([.function, .numericPad])
 
             // Escape (keyCode 53): clear multi-selection (only if >1 selected)
-            if event.keyCode == 53 && self.nodeManager.selectedNodes.count > 1 {
-                self.nodeManager.clearSelection()
+            if event.keyCode == 53 && self.activeNodeManager.selectedNodes.count > 1 {
+                self.activeNodeManager.clearSelection()
                 return nil
             }
 
@@ -209,22 +234,57 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
 
+            // Cmd+1…9: switch to workspace by index
+            if normalizedFlags == [.command],
+               let chars = event.charactersIgnoringModifiers,
+               let digit = chars.first?.wholeNumberValue,
+               digit >= 1 && digit <= 9 {
+                let index = digit - 1
+                if index < self.workspaceManager.workspaces.count {
+                    self.workspaceManager.switchTo(workspace: self.workspaceManager.workspaces[index])
+                    return nil
+                }
+            }
+
             return event
         }
 
-        // Restore saved state or create default terminal
-        if let state = CanvasState.load(), !state.nodes.isEmpty {
-            canvasView.canvasTransform = CanvasTransform(
-                offset: CGPoint(x: state.offsetX, y: state.offsetY),
-                scale: state.scale
-            )
-            for nodeState in state.nodes {
-                let node = nodeManager.createNode(
-                    at: CGPoint(x: nodeState.x, y: nodeState.y),
-                    size: NSSize(width: nodeState.width, height: nodeState.height),
-                    workingDirectory: nodeState.workingDirectory
-                )
-                node.title = nodeState.title
+        // Restore saved state or create default workspace with terminal
+        if let state = CanvasState.load(), let workspaceStates = state.workspaces, !workspaceStates.isEmpty {
+            let activeIdx = state.activeWorkspaceIndex ?? 0
+
+            for (i, wsState) in workspaceStates.enumerated() {
+                let wsId = UUID(uuidString: wsState.id) ?? UUID()
+                let workspace = workspaceManager.createWorkspace(id: wsId, name: wsState.name, switchTo: i == 0)
+
+                if i == 0 {
+                    // First workspace is already active, set its transform
+                    canvasView.canvasTransform = CanvasTransform(
+                        offset: CGPoint(x: wsState.offsetX, y: wsState.offsetY),
+                        scale: wsState.scale
+                    )
+                    workspace.canvasTransform = canvasView.canvasTransform
+                } else {
+                    workspace.canvasTransform = CanvasTransform(
+                        offset: CGPoint(x: wsState.offsetX, y: wsState.offsetY),
+                        scale: wsState.scale
+                    )
+                }
+
+                workspace.nodeManager.delegate = self
+                for nodeState in wsState.nodes {
+                    let node = workspace.nodeManager.createNode(
+                        at: CGPoint(x: nodeState.x, y: nodeState.y),
+                        size: NSSize(width: nodeState.width, height: nodeState.height),
+                        workingDirectory: nodeState.workingDirectory
+                    )
+                    node.title = nodeState.title
+                }
+            }
+
+            // Switch to the previously active workspace
+            if activeIdx > 0 && activeIdx < workspaceManager.workspaces.count {
+                workspaceManager.switchTo(workspace: workspaceManager.workspaces[activeIdx])
             }
 
             if let wx = state.windowX, let wy = state.windowY,
@@ -235,10 +295,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 window.center()
             }
         } else {
-            nodeManager.createNode(at: Self.defaultNodeOrigin, size: Self.defaultNodeSize)
+            // Fresh start: one workspace with one terminal
+            let workspace = workspaceManager.createWorkspace(name: "Workspace 1")
+            workspace.nodeManager.delegate = self
+            canvasView.nodeManager = workspace.nodeManager
+            workspace.nodeManager.createNode(at: Self.defaultNodeOrigin, size: Self.defaultNodeSize)
             window.center()
         }
 
+        syncSidebar()
         window.makeKeyAndOrderFront(nil)
 
         // Poll for process state changes to update sidebar bolt icons
@@ -248,15 +313,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func checkProcessStates() {
-        let currentStates = nodeManager.nodes.map { node -> Bool in
-            guard let surface = node.terminalView.surface else { return false }
-            return ghostty_surface_needs_confirm_quit(surface)
+        // Check across all workspaces
+        var allStates: [Bool] = []
+        for workspace in workspaceManager.workspaces {
+            for node in workspace.nodeManager.nodes {
+                let surface = node.terminalView.surface
+                allStates.append(surface.map { ghostty_surface_needs_confirm_quit($0) } ?? false)
+            }
         }
-        if currentStates != cachedProcessStates {
-            cachedProcessStates = currentStates
-            sidebarModel.update(from: nodeManager)
+        if allStates != cachedProcessStates {
+            cachedProcessStates = allStates
+            sidebarModel.update(from: activeNodeManager)
+            sidebarModel.updateWorkspaces(from: workspaceManager)
             minimapView.refresh()
         }
+    }
+
+    private func syncSidebar() {
+        sidebarModel.update(from: activeNodeManager)
+        sidebarModel.updateWorkspaces(from: workspaceManager)
+        minimapView.nodeManager = activeNodeManager
+        minimapView.refresh()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
@@ -266,12 +343,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         if isConfirmedClose { return .terminateNow }
 
-        let needsConfirm = nodeManager.nodes.contains { node in
-            guard let surface = node.terminalView.surface else { return false }
-            return ghostty_surface_needs_confirm_quit(surface)
-        }
-
-        guard needsConfirm else { return .terminateNow }
+        guard workspaceManager.anyWorkspaceNeedsConfirmation() else { return .terminateNow }
 
         let alert = NSAlert()
         alert.messageText = "Quit Finite?"
@@ -301,7 +373,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         buttonTitle: String = "Close",
         onConfirm: @escaping () -> Void
     ) {
-        guard nodeManager.selectedNodesNeedConfirmation() else {
+        guard activeNodeManager.selectedNodesNeedConfirmation() else {
             onConfirm()
             return
         }
@@ -321,33 +393,33 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Actions
 
     @objc func newTerminal(_ sender: Any?) {
-        let node = nodeManager.createNode(size: Self.defaultNodeSize)
+        let node = activeNodeManager.createNode(size: Self.defaultNodeSize)
         ensureNodeVisible(node)
     }
 
     @objc func duplicateTerminal(_ sender: Any?) {
-        guard let focused = nodeManager.focusedNode else { return }
-        if let node = nodeManager.duplicateNode(focused) {
+        guard let focused = activeNodeManager.focusedNode else { return }
+        if let node = activeNodeManager.duplicateNode(focused) {
             ensureNodeVisible(node)
         }
     }
 
     @objc func closeTerminal(_ sender: Any?) {
-        let selected = nodeManager.selectedNodeViews
+        let selected = activeNodeManager.selectedNodeViews
         if selected.count > 1 {
             closeSelectedTerminals()
-        } else if let focused = nodeManager.focusedNode {
-            nodeManager.requestCloseNode(focused)
+        } else if let focused = activeNodeManager.focusedNode {
+            activeNodeManager.requestCloseNode(focused)
         }
     }
 
     private func closeSelectedTerminals() {
-        let count = nodeManager.selectedNodeViews.count
+        let count = activeNodeManager.selectedNodeViews.count
         showCloseConfirmation(
             message: "Close \(count) terminals?",
             buttonTitle: "Close All"
         ) { [weak self] in
-            self?.nodeManager.closeSelectedNodes()
+            self?.activeNodeManager.closeSelectedNodes()
         }
     }
 
@@ -416,26 +488,71 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func zoomToFitFocused(_ sender: Any?) {
-        if let focused = nodeManager.focusedNode {
+        if let focused = activeNodeManager.focusedNode {
             let sw: CGFloat = sidebarOverlay.isHidden ? 0 : Self.sidebarWidth
             canvasView.zoomToFitNode(focused, sidebarWidth: sw)
         }
     }
 
     @objc func deselectAll(_ sender: Any?) {
-        nodeManager.clearSelection()
+        activeNodeManager.clearSelection()
     }
 
     @objc func tidySelection(_ sender: Any?) {
-        nodeManager.tidySelectedNodes()
+        activeNodeManager.tidySelectedNodes()
+    }
+
+    // MARK: - Workspace Actions
+
+    @objc func newWorkspace(_ sender: Any?) {
+        let name = workspaceManager.nextWorkspaceName()
+        let workspace = workspaceManager.createWorkspace(name: name)
+        workspace.nodeManager.delegate = self
+        workspace.nodeManager.createNode(at: Self.defaultNodeOrigin, size: Self.defaultNodeSize)
+        syncSidebar()
+    }
+
+    @objc func nextWorkspace(_ sender: Any?) {
+        workspaceManager.switchToNext()
+    }
+
+    @objc func previousWorkspace(_ sender: Any?) {
+        workspaceManager.switchToPrevious()
+    }
+
+    private func deleteWorkspace(_ workspace: Workspace) {
+        guard workspaceManager.workspaces.count > 1 else { return }
+
+        let hasRunning = workspace.nodeManager.nodes.contains { node in
+            guard let surface = node.terminalView.surface else { return false }
+            return ghostty_surface_needs_confirm_quit(surface)
+        }
+
+        if hasRunning {
+            let alert = NSAlert()
+            alert.messageText = "Delete \"\(workspace.name)\"?"
+            alert.informativeText = "This workspace has terminals with running processes. Delete anyway?"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Delete")
+            alert.addButton(withTitle: "Cancel")
+            alert.beginSheetModal(for: window) { [weak self] response in
+                if response == .alertFirstButtonReturn {
+                    self?.workspaceManager.deleteWorkspace(workspace)
+                    self?.syncSidebar()
+                }
+            }
+        } else {
+            workspaceManager.deleteWorkspace(workspace)
+            syncSidebar()
+        }
     }
 
     // MARK: - Navigation
 
     private func navigate(_ direction: TerminalNodeManager.Direction) {
-        guard let focused = nodeManager.focusedNode,
-              let target = nodeManager.nearestNode(from: focused, direction: direction) else { return }
-        nodeManager.handleClick(target, modifiers: [])
+        guard let focused = activeNodeManager.focusedNode,
+              let target = activeNodeManager.nearestNode(from: focused, direction: direction) else { return }
+        activeNodeManager.handleClick(target, modifiers: [])
         ensureNodeVisible(target)
     }
 
@@ -494,11 +611,7 @@ extension AppDelegate: NSWindowDelegate {
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if isConfirmedClose { return true }
 
-        let needsConfirm = nodeManager.nodes.contains { node in
-            guard let surface = node.terminalView.surface else { return false }
-            return ghostty_surface_needs_confirm_quit(surface)
-        }
-        guard needsConfirm else { return true }
+        guard workspaceManager.anyWorkspaceNeedsConfirmation() else { return true }
 
         let alert = NSAlert()
         alert.messageText = "Close Finite?"
@@ -524,12 +637,14 @@ extension AppDelegate: NSWindowDelegate {
         processStateTimer = nil
         minimapView.stopRefreshing()
 
-        CanvasState.save(from: nodeManager, transform: canvasView.canvasTransform, windowFrame: window.frame)
+        CanvasState.save(from: workspaceManager, canvasView: canvasView, windowFrame: window.frame)
 
-        nodeManager.isClosingWindow = true
-        for node in nodeManager.nodes {
-            if let surface = node.terminalView.surface {
-                ghostty_surface_request_close(surface)
+        for workspace in workspaceManager.workspaces {
+            workspace.nodeManager.isClosingWindow = true
+            for node in workspace.nodeManager.nodes {
+                if let surface = node.terminalView.surface {
+                    ghostty_surface_request_close(surface)
+                }
             }
         }
     }
@@ -539,7 +654,8 @@ extension AppDelegate: NSWindowDelegate {
 
 extension AppDelegate: TerminalNodeManagerDelegate {
     private func syncUI(_ manager: TerminalNodeManager) {
-        sidebarModel.update(from: manager)
+        sidebarModel.update(from: activeNodeManager)
+        sidebarModel.updateWorkspaces(from: workspaceManager)
         minimapView.refresh()
     }
 
@@ -554,5 +670,30 @@ extension AppDelegate: TerminalNodeManagerDelegate {
     func nodeManager(_ manager: TerminalNodeManager, didUpdateTitleFor node: TerminalNodeView) { syncUI(manager) }
     func nodeManager(_ manager: TerminalNodeManager, didUpdateActivityFor node: TerminalNodeView) { syncUI(manager) }
     func nodeManager(_ manager: TerminalNodeManager, didUpdateSelection selectedNodes: Set<ObjectIdentifier>) { syncUI(manager) }
-    func nodeManagerDidRemoveLastNode(_ manager: TerminalNodeManager) { window.close() }
+    func nodeManagerDidRemoveLastNode(_ manager: TerminalNodeManager) {
+        // Only close if ALL workspaces are empty
+        if workspaceManager.allWorkspacesEmpty {
+            window.close()
+        }
+    }
+}
+
+// MARK: - WorkspaceManagerDelegate
+
+extension AppDelegate: WorkspaceManagerDelegate {
+    func workspaceManager(_ manager: WorkspaceManager, didSwitchTo workspace: Workspace) {
+        syncSidebar()
+    }
+
+    func workspaceManager(_ manager: WorkspaceManager, didAdd workspace: Workspace) {
+        syncSidebar()
+    }
+
+    func workspaceManager(_ manager: WorkspaceManager, didRemove workspace: Workspace) {
+        syncSidebar()
+    }
+
+    func workspaceManager(_ manager: WorkspaceManager, didRename workspace: Workspace) {
+        syncSidebar()
+    }
 }

--- a/Finite/Sources/Canvas/CanvasState.swift
+++ b/Finite/Sources/Canvas/CanvasState.swift
@@ -4,7 +4,7 @@ import os
 
 private let logger = Logger(subsystem: "com.helm.finite", category: "CanvasState")
 
-/// Persisted canvas state — node layout and canvas transform.
+/// Persisted canvas state — supports multiple workspaces.
 struct CanvasState: Codable {
     struct NodeState: Codable {
         var x: CGFloat
@@ -15,10 +15,26 @@ struct CanvasState: Codable {
         var workingDirectory: String?
     }
 
-    var nodes: [NodeState]
-    var offsetX: CGFloat
-    var offsetY: CGFloat
-    var scale: CGFloat
+    struct WorkspaceState: Codable {
+        var id: String
+        var name: String
+        var nodes: [NodeState]
+        var offsetX: CGFloat
+        var offsetY: CGFloat
+        var scale: CGFloat
+    }
+
+    // New multi-workspace format
+    var workspaces: [WorkspaceState]?
+    var activeWorkspaceIndex: Int?
+
+    // Legacy single-workspace format (for migration)
+    var nodes: [NodeState]?
+    var offsetX: CGFloat?
+    var offsetY: CGFloat?
+    var scale: CGFloat?
+
+    // Window frame (shared)
     var windowX: CGFloat?
     var windowY: CGFloat?
     var windowWidth: CGFloat?
@@ -28,23 +44,34 @@ struct CanvasState: Codable {
         .appendingPathComponent(".config/finite")
     private static let stateFile = configDir.appendingPathComponent("state.json")
 
-    static func save(from manager: TerminalNodeManager, transform: CanvasTransform, windowFrame: NSRect? = nil) {
-        let nodeStates = manager.nodes.map { node in
-            NodeState(
-                x: node.frame.origin.x,
-                y: node.frame.origin.y,
-                width: node.frame.width,
-                height: node.frame.height,
-                title: node.title,
-                workingDirectory: manager.pwd(for: node)
+    static func save(from workspaceManager: WorkspaceManager, canvasView: CanvasView, windowFrame: NSRect? = nil) {
+        // Save current workspace's transform from the live canvas
+        workspaceManager.activeWorkspace.canvasTransform = canvasView.canvasTransform
+
+        let workspaceStates = workspaceManager.workspaces.map { workspace in
+            let nodeStates = workspace.nodeManager.nodes.map { node in
+                NodeState(
+                    x: node.frame.origin.x,
+                    y: node.frame.origin.y,
+                    width: node.frame.width,
+                    height: node.frame.height,
+                    title: node.title,
+                    workingDirectory: workspace.nodeManager.pwd(for: node)
+                )
+            }
+            return WorkspaceState(
+                id: workspace.id.uuidString,
+                name: workspace.name,
+                nodes: nodeStates,
+                offsetX: workspace.canvasTransform.offset.x,
+                offsetY: workspace.canvasTransform.offset.y,
+                scale: workspace.canvasTransform.scale
             )
         }
 
         let state = CanvasState(
-            nodes: nodeStates,
-            offsetX: transform.offset.x,
-            offsetY: transform.offset.y,
-            scale: transform.scale,
+            workspaces: workspaceStates,
+            activeWorkspaceIndex: workspaceManager.activeIndex,
             windowX: windowFrame?.origin.x,
             windowY: windowFrame?.origin.y,
             windowWidth: windowFrame?.width,
@@ -62,6 +89,22 @@ struct CanvasState: Codable {
 
     static func load() -> CanvasState? {
         guard let data = try? Data(contentsOf: stateFile) else { return nil }
-        return try? JSONDecoder().decode(CanvasState.self, from: data)
+        guard var state = try? JSONDecoder().decode(CanvasState.self, from: data) else { return nil }
+
+        // Migrate legacy single-workspace format
+        if state.workspaces == nil, let nodes = state.nodes {
+            let legacyWorkspace = WorkspaceState(
+                id: UUID().uuidString,
+                name: "Workspace 1",
+                nodes: nodes,
+                offsetX: state.offsetX ?? 0,
+                offsetY: state.offsetY ?? 0,
+                scale: state.scale ?? 1
+            )
+            state.workspaces = [legacyWorkspace]
+            state.activeWorkspaceIndex = 0
+        }
+
+        return state
     }
 }

--- a/Finite/Sources/Canvas/CanvasView.swift
+++ b/Finite/Sources/Canvas/CanvasView.swift
@@ -95,6 +95,26 @@ class CanvasView: NSView {
         gridView?.needsDisplay = true
     }
 
+    /// Remove all terminal nodes from the view hierarchy without destroying them.
+    func detachAllNodes() {
+        for node in terminalNodes {
+            node.removeFromSuperview()
+        }
+        terminalNodes.removeAll()
+        gridView?.needsDisplay = true
+    }
+
+    /// Add pre-existing terminal nodes back into the view hierarchy.
+    func attachNodes(_ nodes: [TerminalNodeView]) {
+        for node in nodes {
+            terminalNodes.append(node)
+            addSubview(node)
+            node.canvasView = self
+            node.terminalView.canvasView = self
+        }
+        gridView?.needsDisplay = true
+    }
+
     func bringNodeToFront(_ node: TerminalNodeView) {
         guard let idx = terminalNodes.firstIndex(where: { $0 === node }) else { return }
         terminalNodes.remove(at: idx)

--- a/Finite/Sources/Sidebar/SidebarView.swift
+++ b/Finite/Sources/Sidebar/SidebarView.swift
@@ -10,14 +10,30 @@ struct NodeItem: Identifiable {
     let node: TerminalNodeView?
 }
 
+struct WorkspaceItem: Identifiable {
+    let id: UUID
+    let name: String
+    let terminalCount: Int
+    let isActive: Bool
+}
+
 final class SidebarModel: ObservableObject {
     @Published var nodes: [NodeItem] = []
+    @Published var workspaceItems: [WorkspaceItem] = []
+
+    // Terminal callbacks
     var onSelectNode: ((TerminalNodeView, NSEvent.ModifierFlags) -> Void)?
     var onCloseSelected: (() -> Void)?
     var onCloseSingle: ((TerminalNodeView) -> Void)?
     var onDuplicateNode: ((TerminalNodeView) -> Void)?
     var onPanToNode: ((TerminalNodeView) -> Void)?
     var onHoverPulse: ((TerminalNodeView) -> Void)?
+
+    // Workspace callbacks
+    var onSelectWorkspace: ((UUID) -> Void)?
+    var onCreateWorkspace: (() -> Void)?
+    var onDeleteWorkspace: ((UUID) -> Void)?
+    var onRenameWorkspace: ((UUID, String) -> Void)?
 
     func update(from manager: TerminalNodeManager) {
         nodes = manager.nodes.map { node in
@@ -38,6 +54,17 @@ final class SidebarModel: ObservableObject {
             )
         }
     }
+
+    func updateWorkspaces(from workspaceManager: WorkspaceManager) {
+        workspaceItems = workspaceManager.workspaces.enumerated().map { index, workspace in
+            WorkspaceItem(
+                id: workspace.id,
+                name: workspace.name,
+                terminalCount: workspace.nodeManager.nodes.count,
+                isActive: index == workspaceManager.activeIndex
+            )
+        }
+    }
 }
 
 struct SidebarView: View {
@@ -45,6 +72,38 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Workspaces section
+            HStack {
+                Text("Workspaces")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button(action: { model.onCreateWorkspace?() }) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            ForEach(model.workspaceItems) { item in
+                SidebarWorkspaceRow(item: item, model: model)
+                    .onTapGesture {
+                        model.onSelectWorkspace?(item.id)
+                    }
+                    .contextMenu {
+                        workspaceContextMenu(for: item)
+                    }
+            }
+            .padding(.horizontal, 4)
+
+            Divider()
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+
+            // Terminals section
             Text("Terminals")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundColor(.secondary)
@@ -68,7 +127,7 @@ struct SidebarView: View {
                                 }
                             }
                             .contextMenu {
-                                contextMenuItems(for: item)
+                                terminalContextMenu(for: item)
                             }
                     }
                 }
@@ -80,7 +139,44 @@ struct SidebarView: View {
     }
 
     @ViewBuilder
-    private func contextMenuItems(for item: NodeItem) -> some View {
+    private func workspaceContextMenu(for item: WorkspaceItem) -> some View {
+        Button("Rename Workspace...") {
+            promptRename(for: item)
+        }
+        if model.workspaceItems.count > 1 {
+            Button("Delete Workspace") {
+                model.onDeleteWorkspace?(item.id)
+            }
+        }
+    }
+
+    private func promptRename(for item: WorkspaceItem) {
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Rename Workspace"
+            alert.informativeText = "Enter a new name for this workspace."
+            alert.addButton(withTitle: "Rename")
+            alert.addButton(withTitle: "Cancel")
+
+            let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+            textField.stringValue = item.name
+            alert.accessoryView = textField
+
+            if let window = NSApp.keyWindow {
+                alert.beginSheetModal(for: window) { response in
+                    if response == .alertFirstButtonReturn {
+                        let newName = textField.stringValue.trimmingCharacters(in: .whitespaces)
+                        if !newName.isEmpty {
+                            model.onRenameWorkspace?(item.id, newName)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func terminalContextMenu(for item: NodeItem) -> some View {
         let selectedCount = model.nodes.filter { $0.isSelected }.count
 
         if selectedCount > 1 {
@@ -103,6 +199,55 @@ struct SidebarView: View {
         }
     }
 }
+
+// MARK: - Workspace Row
+
+struct SidebarWorkspaceRow: View {
+    let item: WorkspaceItem
+    let model: SidebarModel
+
+    private var dotColor: Color {
+        item.isActive ? .accentColor : Color.white.opacity(0.2)
+    }
+
+    private var rowBackground: Color {
+        item.isActive ? Color.accentColor.opacity(0.12) : Color.clear
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 8, height: 8)
+
+            Text(item.name)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer()
+
+            Text("\(item.terminalCount)")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(
+                    Capsule()
+                        .fill(Color.white.opacity(0.08))
+                )
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(rowBackground)
+        )
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Terminal Node Row
 
 struct SidebarNodeRow: View {
     let item: NodeItem

--- a/Finite/Sources/Terminal/TerminalNodeManager.swift
+++ b/Finite/Sources/Terminal/TerminalNodeManager.swift
@@ -36,7 +36,6 @@ class TerminalNodeManager {
     init(canvasView: CanvasView, window: NSWindow) {
         self.canvasView = canvasView
         self.window = window
-        canvasView.nodeManager = self
     }
 
     // MARK: - Node Creation

--- a/Finite/Sources/Workspace/Workspace.swift
+++ b/Finite/Sources/Workspace/Workspace.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+/// A workspace groups a set of terminal nodes with their own canvas transform.
+/// All terminals stay alive in memory when the workspace is inactive.
+class Workspace: Identifiable {
+    let id: UUID
+    var name: String
+    let nodeManager: TerminalNodeManager
+    var canvasTransform: CanvasTransform
+
+    init(id: UUID = UUID(), name: String, canvasView: CanvasView, window: NSWindow) {
+        self.id = id
+        self.name = name
+        self.nodeManager = TerminalNodeManager(canvasView: canvasView, window: window)
+        self.canvasTransform = CanvasTransform()
+    }
+}

--- a/Finite/Sources/Workspace/WorkspaceManager.swift
+++ b/Finite/Sources/Workspace/WorkspaceManager.swift
@@ -1,0 +1,170 @@
+import AppKit
+
+protocol WorkspaceManagerDelegate: AnyObject {
+    func workspaceManager(_ manager: WorkspaceManager, didSwitchTo workspace: Workspace)
+    func workspaceManager(_ manager: WorkspaceManager, didAdd workspace: Workspace)
+    func workspaceManager(_ manager: WorkspaceManager, didRemove workspace: Workspace)
+    func workspaceManager(_ manager: WorkspaceManager, didRename workspace: Workspace)
+}
+
+/// Manages multiple workspaces, each with its own set of terminals and canvas transform.
+class WorkspaceManager {
+    weak var delegate: WorkspaceManagerDelegate?
+    private(set) var workspaces: [Workspace] = []
+    private(set) var activeIndex: Int = 0
+    private weak var canvasView: CanvasView?
+    private weak var window: NSWindow?
+
+    var activeWorkspace: Workspace { workspaces[activeIndex] }
+
+    init(canvasView: CanvasView, window: NSWindow) {
+        self.canvasView = canvasView
+        self.window = window
+    }
+
+    // MARK: - Create / Delete / Rename
+
+    @discardableResult
+    func createWorkspace(name: String, switchTo: Bool = true) -> Workspace {
+        guard let canvasView, let window else { fatalError("CanvasView/Window deallocated") }
+        let workspace = Workspace(name: name, canvasView: canvasView, window: window)
+        workspaces.append(workspace)
+        delegate?.workspaceManager(self, didAdd: workspace)
+        if switchTo {
+            self.switchTo(workspace: workspace)
+        }
+        return workspace
+    }
+
+    /// Create a workspace with a pre-existing id (for state restoration).
+    @discardableResult
+    func createWorkspace(id: UUID, name: String, switchTo: Bool = true) -> Workspace {
+        guard let canvasView, let window else { fatalError("CanvasView/Window deallocated") }
+        let workspace = Workspace(id: id, name: name, canvasView: canvasView, window: window)
+        workspaces.append(workspace)
+        delegate?.workspaceManager(self, didAdd: workspace)
+        if switchTo {
+            self.switchTo(workspace: workspace)
+        }
+        return workspace
+    }
+
+    func deleteWorkspace(_ workspace: Workspace) {
+        guard workspaces.count > 1 else { return }
+        guard let idx = workspaces.firstIndex(where: { $0.id == workspace.id }) else { return }
+
+        let isActive = idx == activeIndex
+
+        // Close all terminals in the workspace
+        for node in workspace.nodeManager.nodes {
+            if let surface = node.terminalView.surface {
+                ghostty_surface_request_close(surface)
+            }
+        }
+
+        // If active, detach its nodes from the canvas
+        if isActive {
+            canvasView?.detachAllNodes()
+        }
+
+        workspaces.remove(at: idx)
+
+        // Adjust activeIndex
+        if isActive {
+            let newIndex = min(idx, workspaces.count - 1)
+            activeIndex = newIndex
+            attachWorkspace(workspaces[newIndex])
+        } else if idx < activeIndex {
+            activeIndex -= 1
+        }
+
+        delegate?.workspaceManager(self, didRemove: workspace)
+    }
+
+    func renameWorkspace(_ workspace: Workspace, to name: String) {
+        workspace.name = name
+        delegate?.workspaceManager(self, didRename: workspace)
+    }
+
+    // MARK: - Switching
+
+    func switchTo(workspace: Workspace) {
+        guard let canvasView else { return }
+        guard let targetIndex = workspaces.firstIndex(where: { $0.id == workspace.id }) else { return }
+        if targetIndex == activeIndex && !canvasView.terminalNodes.isEmpty { return }
+
+        let current = workspaces[activeIndex]
+
+        // Save current transform and detach nodes
+        current.canvasTransform = canvasView.canvasTransform
+        canvasView.detachAllNodes()
+
+        // Activate target
+        activeIndex = targetIndex
+        attachWorkspace(workspace)
+
+        delegate?.workspaceManager(self, didSwitchTo: workspace)
+    }
+
+    func switchToNext() {
+        let next = (activeIndex + 1) % workspaces.count
+        switchTo(workspace: workspaces[next])
+    }
+
+    func switchToPrevious() {
+        let prev = (activeIndex - 1 + workspaces.count) % workspaces.count
+        switchTo(workspace: workspaces[prev])
+    }
+
+    // MARK: - Surface Routing
+
+    /// Find the node manager that owns a given surface (searches all workspaces).
+    func nodeManager(for surface: ghostty_surface_t) -> TerminalNodeManager? {
+        for workspace in workspaces {
+            if workspace.nodeManager.node(for: surface) != nil {
+                return workspace.nodeManager
+            }
+        }
+        return nil
+    }
+
+    /// Check if any workspace has terminals with running processes.
+    func anyWorkspaceNeedsConfirmation() -> Bool {
+        workspaces.contains { workspace in
+            workspace.nodeManager.nodes.contains { node in
+                guard let surface = node.terminalView.surface else { return false }
+                return ghostty_surface_needs_confirm_quit(surface)
+            }
+        }
+    }
+
+    /// Check if all workspaces are empty.
+    var allWorkspacesEmpty: Bool {
+        workspaces.allSatisfy { $0.nodeManager.nodes.isEmpty }
+    }
+
+    /// Next workspace number for auto-naming.
+    func nextWorkspaceName() -> String {
+        let existing = workspaces.compactMap { ws -> Int? in
+            guard ws.name.hasPrefix("Workspace ") else { return nil }
+            return Int(ws.name.dropFirst("Workspace ".count))
+        }
+        let next = (existing.max() ?? 0) + 1
+        return "Workspace \(next)"
+    }
+
+    // MARK: - Private
+
+    private func attachWorkspace(_ workspace: Workspace) {
+        guard let canvasView else { return }
+
+        canvasView.attachNodes(workspace.nodeManager.nodes)
+        canvasView.canvasTransform = workspace.canvasTransform
+        canvasView.nodeManager = workspace.nodeManager
+
+        // Restore keyboard focus
+        if let focused = workspace.nodeManager.focusedNode {
+            window?.makeFirstResponder(focused.terminalView)
+        }
+    }
+}

--- a/Finite/Sources/main.swift
+++ b/Finite/Sources/main.swift
@@ -51,6 +51,17 @@ terminalMenu.addItem(NSMenuItem.separator())
 let closeItem = terminalMenu.addItem(withTitle: "Close Terminal", action: #selector(AppDelegate.closeTerminal(_:)), keyEquivalent: "w")
 closeItem.keyEquivalentModifierMask = [.command]
 
+terminalMenu.addItem(NSMenuItem.separator())
+
+let newWSItem = terminalMenu.addItem(withTitle: "New Workspace", action: #selector(AppDelegate.newWorkspace(_:)), keyEquivalent: "n")
+newWSItem.keyEquivalentModifierMask = [.command, .shift]
+
+let nextWSItem = terminalMenu.addItem(withTitle: "Next Workspace", action: #selector(AppDelegate.nextWorkspace(_:)), keyEquivalent: "]")
+nextWSItem.keyEquivalentModifierMask = [.command, .shift]
+
+let prevWSItem = terminalMenu.addItem(withTitle: "Previous Workspace", action: #selector(AppDelegate.previousWorkspace(_:)), keyEquivalent: "[")
+prevWSItem.keyEquivalentModifierMask = [.command, .shift]
+
 terminalMenuItem.submenu = terminalMenu
 
 // -- View menu --

--- a/README.md
+++ b/README.md
@@ -78,9 +78,22 @@ Drag terminals by their title bar, or `Opt+Drag` from anywhere on the terminal. 
 | `Cmd+Opt+F` | Zoom to fit focused terminal |
 | `Cmd+Opt+0` | Zoom to fit all |
 
+### Workspaces
+
+Workspaces let you group terminals into separate canvases. Each workspace has its own terminals, layout, and zoom level. All workspaces stay live in memory for instant switching.
+
+| Action | Shortcut |
+|---|---|
+| New Workspace | `Cmd+Shift+N` |
+| Next Workspace | `Cmd+Shift+]` |
+| Previous Workspace | `Cmd+Shift+[` |
+| Switch to Workspace 1–9 | `Cmd+1` … `Cmd+9` |
+
+Workspaces are listed in the sidebar above the terminal list. Click to switch, right-click to rename or delete.
+
 ### Sidebar
 
-Toggle with `Cmd+Opt+S`. Lists all terminals with status indicators: focused (blue), selected (faded blue), activity (pulsing orange), running process (bolt icon). Hovering a row briefly pulses the terminal on the canvas.
+Toggle with `Cmd+Opt+S`. Shows workspaces at the top and the active workspace's terminals below. Terminal status indicators: focused (blue), selected (faded blue), activity (pulsing orange), running process (bolt icon). Hovering a row briefly pulses the terminal on the canvas.
 
 ### Minimap
 
@@ -97,6 +110,10 @@ Window position, canvas transform, terminal layout, and working directories are 
 | `Cmd+N` | New Terminal |
 | `Cmd+Shift+D` | Duplicate Terminal |
 | `Cmd+W` | Close Terminal |
+| `Cmd+Shift+N` | New Workspace |
+| `Cmd+Shift+]` | Next Workspace |
+| `Cmd+Shift+[` | Previous Workspace |
+| `Cmd+1` … `Cmd+9` | Switch to Workspace 1–9 |
 | `Cmd+Opt+S` | Toggle Sidebar |
 | `Cmd+Opt+M` | Toggle Minimap |
 | `Cmd+Opt+0` | Zoom to Fit All |


### PR DESCRIPTION
  ## Introduction 
  
 First of all thank you for setting this up I'm in love with this concept and really enjoy the experience. One key feature I was missing was the ability to have multiple workspaces for example for different projects.
  
  ## Summary
  - Adds workspaces — independent groups of terminals, each with its own canvas layout and zoom level. All workspaces remain live in memory for instant switching.
  - New `Workspace` and `WorkspaceManager` classes handle workspace lifecycle (create, delete, rename, switch). Ghostty runtime callbacks are routed to the correct workspace's node manager via surface lookup.
  - Sidebar updated with a workspace section (click to switch, right-click to rename/delete). Canvas state persistence migrated to a multi-workspace format with backward-compatible loading of the legacy single-workspace format.

  ## Keyboard shortcuts
  | Action | Shortcut |
  |---|---|
  | New Workspace | `Cmd+Shift+N` |
  | Next / Previous Workspace | `Cmd+Shift+]` / `Cmd+Shift+[` |
  | Switch to Workspace 1–9 | `Cmd+1` … `Cmd+9` |

  ## Key changes
  - **New files:** `Workspace.swift`, `WorkspaceManager.swift`
  - **AppDelegate:** Replaced direct `TerminalNodeManager` usage with `WorkspaceManager`; all terminal actions route through `activeNodeManager`
  - **CanvasView:** Added `detachAllNodes()` / `attachNodes(_:)` for swapping workspace node sets
  - **CanvasState:** New `WorkspaceState` nested type with automatic migration from the old flat format
  - **SidebarView:** Workspace list with active indicator, terminal count badge, rename/delete context menu
  - **Menu bar:** Added workspace menu items under the Terminal menu