### PR TITLE
feat: Added support middle mouse drag and command zoom in the canvas

### DIFF
--- a/Finite/Sources/Canvas/CanvasView.swift
+++ b/Finite/Sources/Canvas/CanvasView.swift
@@ -27,6 +27,9 @@ class CanvasView: NSView {
     private var marqueeStart: CGPoint?
     private(set) var marqueeRect: NSRect?
 
+    /// Middle-mouse drag panning state.
+    private var middleMousePanStart: NSPoint?
+
     // MARK: - Scroll State Machine
 
     private enum ScrollTarget {
@@ -254,6 +257,29 @@ class CanvasView: NSView {
         let intersecting = terminalNodes.filter { $0.frame.intersects(rect) }
         let cmdHeld = event.modifierFlags.contains(.command)
         manager.marqueeSelect(nodes: intersecting, toggle: cmdHeld)
+    }
+
+    // MARK: - Middle Mouse Drag (pan canvas, Figma-style)
+
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2 else { return super.otherMouseDown(with: event) }
+        middleMousePanStart = event.locationInWindow
+        NSCursor.closedHand.push()
+    }
+
+    override func otherMouseDragged(with event: NSEvent) {
+        guard event.buttonNumber == 2, middleMousePanStart != nil else {
+            return super.otherMouseDragged(with: event)
+        }
+        canvasTransform.pan(by: CGPoint(x: -event.deltaX, y: event.deltaY))
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        guard event.buttonNumber == 2, middleMousePanStart != nil else {
+            return super.otherMouseUp(with: event)
+        }
+        middleMousePanStart = nil
+        NSCursor.pop()
     }
 
     func zoomToFitAll(sidebarWidth: CGFloat = 0) {

--- a/Finite/Sources/Canvas/CanvasView.swift
+++ b/Finite/Sources/Canvas/CanvasView.swift
@@ -331,6 +331,15 @@ class CanvasView: NSView {
             scrollTarget = .canvas
         }
 
+        // Cmd+scroll: zoom in/out using vertical scroll delta
+        if event.modifierFlags.contains(.command) {
+            let anchor = convert(event.locationInWindow, from: nil)
+            let zoomSensitivity: CGFloat = 0.01
+            let factor = 1.0 + event.scrollingDeltaY * zoomSensitivity
+            canvasTransform.zoom(by: factor, anchor: anchor)
+            return
+        }
+
         // Route based on target
         switch scrollTarget {
         case .undecided:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make release  # release build, installs to /Applications
 
 ### Canvas
 
-The canvas is infinite. Pan with the trackpad, scroll wheel, or middle-mouse drag. Zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
+The canvas is infinite. Pan with the trackpad, scroll wheel, or middle-mouse drag. Zoom with pinch gestures or `Cmd+Scroll`. Double-click empty space to zoom to fit all terminals.
 
 Scroll direction is detected automatically: horizontal scrolling pans the canvas, vertical scrolling goes to the terminal under the cursor. Hold `Ctrl` to force canvas panning.
 
@@ -107,6 +107,7 @@ Window position, canvas transform, terminal layout, and working directories are 
 | `Cmd+Click` | Toggle selection |
 | `Opt+Drag` | Move terminal from anywhere |
 | `Middle Mouse Drag` | Pan canvas |
+| `Cmd+Scroll` | Zoom canvas |
 | `Ctrl+Scroll` | Force canvas pan |
 | `Cmd` (while dragging) | Disable snap guides |
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make release  # release build, installs to /Applications
 
 ### Canvas
 
-The canvas is infinite. Pan with the trackpad, scroll wheel, or middle-mouse drag (like Figma). Zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
+The canvas is infinite. Pan with the trackpad, scroll wheel, or middle-mouse drag. Zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
 
 Scroll direction is detected automatically: horizontal scrolling pans the canvas, vertical scrolling goes to the terminal under the cursor. Hold `Ctrl` to force canvas panning.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make release  # release build, installs to /Applications
 
 ### Canvas
 
-The canvas is infinite. Pan with the trackpad or scroll wheel, zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
+The canvas is infinite. Pan with the trackpad, scroll wheel, or middle-mouse drag (like Figma). Zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
 
 Scroll direction is detected automatically: horizontal scrolling pans the canvas, vertical scrolling goes to the terminal under the cursor. Hold `Ctrl` to force canvas panning.
 
@@ -106,6 +106,7 @@ Window position, canvas transform, terminal layout, and working directories are 
 | `Escape` | Deselect All |
 | `Cmd+Click` | Toggle selection |
 | `Opt+Drag` | Move terminal from anywhere |
+| `Middle Mouse Drag` | Pan canvas |
 | `Ctrl+Scroll` | Force canvas pan |
 | `Cmd` (while dragging) | Disable snap guides |
 


### PR DESCRIPTION
## Summary

  - Add middle-mouse drag to pan the canvas, matching the interaction model used by Figma and other spatial tools
  - Hold the Command key and scroll the mouse wheel to zoom in/out, anchored at the cursor position.
  - Update README to document the new input method

## Changes

  - **CanvasView.swift**: Added `otherMouseDown`, `otherMouseDragged`, and `otherMouseUp` overrides to handle middle-mouse button (button 2) drag panning with a closed-hand
  cursor during drag
  - **README.md**: Added middle-mouse drag to the canvas description and shortcuts table, added explanation about command zoom behaviour 