### PR TITLE
feat: Add Cmd+Scroll zoom for the canvas

### DIFF
--- a/Finite/Sources/Canvas/CanvasView.swift
+++ b/Finite/Sources/Canvas/CanvasView.swift
@@ -305,6 +305,15 @@ class CanvasView: NSView {
             scrollTarget = .canvas
         }
 
+        // Cmd+scroll: zoom in/out using vertical scroll delta
+        if event.modifierFlags.contains(.command) {
+            let anchor = convert(event.locationInWindow, from: nil)
+            let zoomSensitivity: CGFloat = 0.01
+            let factor = 1.0 + event.scrollingDeltaY * zoomSensitivity
+            canvasTransform.zoom(by: factor, anchor: anchor)
+            return
+        }
+
         // Route based on target
         switch scrollTarget {
         case .undecided:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make release  # release build, installs to /Applications
 
 ### Canvas
 
-The canvas is infinite. Pan with the trackpad or scroll wheel, zoom with pinch gestures. Double-click empty space to zoom to fit all terminals.
+The canvas is infinite. Pan with the trackpad or scroll wheel, zoom with pinch gestures or `Cmd+Scroll`. Double-click empty space to zoom to fit all terminals.
 
 Scroll direction is detected automatically: horizontal scrolling pans the canvas, vertical scrolling goes to the terminal under the cursor. Hold `Ctrl` to force canvas panning.
 
@@ -106,6 +106,7 @@ Window position, canvas transform, terminal layout, and working directories are 
 | `Escape` | Deselect All |
 | `Cmd+Click` | Toggle selection |
 | `Opt+Drag` | Move terminal from anywhere |
+| `Cmd+Scroll` | Zoom canvas |
 | `Ctrl+Scroll` | Force canvas pan |
 | `Cmd` (while dragging) | Disable snap guides |
 


### PR DESCRIPTION
## Summary

Hold the Command key and scroll the mouse wheel to zoom in/out, anchored at the cursor position. Matches Figma-style zoom behavior.